### PR TITLE
create logo component

### DIFF
--- a/resources/views/components/logo.blade.php
+++ b/resources/views/components/logo.blade.php
@@ -1,0 +1,16 @@
+@props([
+    "showText",
+    "responsive" => false,
+])
+
+<div
+    class="text-sun-400 fixed flex w-full gap-2 bg-neutral-900 text-2xl font-bold"
+>
+    <img src="{{ asset("images/logomark.svg") }}" alt="Movie Scout" />
+
+    @if ($showText)
+        <span class="{{ $responsive ? "hidden md:inline" : null }}">
+            Movie Scout
+        </span>
+    @endif
+</div>

--- a/resources/views/components/logo.blade.php
+++ b/resources/views/components/logo.blade.php
@@ -3,9 +3,7 @@
     "responsive" => false,
 ])
 
-<div
-    class="text-sun-400 fixed flex w-full gap-2 bg-neutral-900 text-2xl font-bold"
->
+<div class="text-sun-400 fixed flex w-full gap-2 text-2xl font-bold">
     <img src="{{ asset("images/logomark.svg") }}" alt="Movie Scout" />
 
     @if ($showText)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,13 @@ export default {
             fontFamily: {
                 outfit: ["Outfit", ...defaultTheme.fontFamily.sans],
             },
+
+            colors: {
+                sun: {
+                    400: "#CA362E",
+                    500: "#9D2924"
+                }
+            }
         },
     },
 


### PR DESCRIPTION
Made a responsive logo component with with props "showText" and "responsive".
![image](https://github.com/user-attachments/assets/847394bc-8998-4760-8a34-844b3d0fa0c3)
Depending on where we want text either be, show/dont show/responsive

![image](https://github.com/user-attachments/assets/74ff27ac-3bfa-4b61-8bbd-cf6fc0e6e19a)
Responsive being the most confusing one using two conditions depending on its placement.
The picture above show a mobile version using the logo component differently in footer and header.
