### PR TITLE
Create a base layout for future cards

### DIFF
--- a/resources/views/components/base-card.blade.php
+++ b/resources/views/components/base-card.blade.php
@@ -1,0 +1,3 @@
+<div class="rounded-2 flex gap-4 bg-neutral-900 p-4">
+    {{ $slot }}
+</div>


### PR DESCRIPTION
Created a base card layout for our cards that will be used for #102 and #99 that would look similiar to this at the end
![image](https://github.com/user-attachments/assets/176a903e-14c2-4923-9144-4a34a3145b7b)
![image](https://github.com/user-attachments/assets/9e335d8a-eba2-40cf-8955-d6c07cffc562)
