### PR TITLE
Fix main layout

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -8,7 +8,7 @@
         "bg-sun-400 hover:bg-sun-500" => $variant === "primary",
         "bg-neutral-900 hover:bg-neutral-700" => $variant === "secondary",
         "w-full" => $wide,
-        "item-center flex gap-2 text-nowrap rounded-full px-4 py-2 font-bold transition",
+        "flex items-center justify-center gap-2 text-nowrap rounded-full px-4 py-2 font-bold transition",
     ])
 >
     @if (isset($icon))

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,4 +1,4 @@
-<footer class="bg-neutral-900 px-28 py-12 flex gap-4 flex-col">
+<footer class="bg-neutral-900 px-28 py-12 flex gap-4 flex-col w-full">
     <div class="flex flex-row">
         <a href="/"><x-logo showText />
     

--- a/resources/views/components/main-layout.blade.php
+++ b/resources/views/components/main-layout.blade.php
@@ -13,7 +13,7 @@
         <main class="w-full max-w-5xl px-4">
             {{ $slot }}
         </main>
-        
+
         <x-footer />
     </body>
 </html>

--- a/resources/views/components/main-layout.blade.php
+++ b/resources/views/components/main-layout.blade.php
@@ -7,12 +7,13 @@
         <link rel="icon" href="{{ asset("images/logomark.svg") }}" />
         @vite(["resources/css/app.css", "resources/js/app.js"])
     </head>
-    <body>
+    <body class="flex flex-col items-center">
         <x-header />
 
-        <main>
+        <main class="w-full max-w-5xl px-4">
             {{ $slot }}
         </main>
+        
         <x-footer />
     </body>
 </html>


### PR DESCRIPTION
Fixed so content in main will be centered using `max-w-5xl` (65rem). This aprox 10rem smaller than the Figma making it look like majour changes have happened visually. Any content will now have a max width instead of using margin like we have done in Figma.
![image](https://github.com/user-attachments/assets/ab6040c6-c391-4758-9b26-78c22fb50a98)

When testing i saw that button was missing a `justify-center` in its class and footer was missing `w-full`.
Also corrected spelling error in button.