### PR TITLE
create trailer component

### DIFF
--- a/resources/views/components/trailer.blade.php
+++ b/resources/views/components/trailer.blade.php
@@ -1,0 +1,31 @@
+@props([
+    "source",
+    "title"
+    "plot",
+    "rating",
+])
+<div class="relative aspect-video overflow-hidden rounded-lg pb-10">
+    <iframe
+        src="{{ $source }}"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+        class="size-full"
+    ></iframe>
+
+    <div
+        class="pointer-events-none absolute inset-x-0 bottom-0 z-10 flex items-end justify-between gap-4 bg-gradient-to-t from-neutral-900 from-50% to-90% p-4"
+    >
+        <div class="flex min-w-0 flex-col">
+            <h2
+                class="line-clamp-2 break-words font-bold md:line-clamp-3 md:text-xl"
+            >
+                {{ $title }}
+            </h2>
+            <p>{{ $plot }}</p>
+        </div>
+        {{-- Needs prop: rating --}}
+        <div>rating-component</div>
+    </div>
+</div>


### PR DESCRIPTION
Created a responsive trailer component, awaiting #109 for completion.
Since we wont store videos and images in our database. They would have their source URL linked instead. using `iframe` from youtube as example.

However, due to licenses - watermarks will be showing and to keep the same style as in the projects Figma, i made padding to create something similiar to our Figma project. Not my proudest work, but changes like putting the text-div separate in the bottom would stand out on our website but (would make it more accessebility friendly).
With the class `pointer-events-none` i made it so you can press the controllers in the background to example, controll the volume, skip and rewind fullscreen.

Can be solved easily but would need discussion if we would decide on it.. and i dont think we have all that time if we want to finish the deadline.

https://github.com/user-attachments/assets/21cfff2d-f093-4d08-9f46-65fd0dc6a252

