### PR TITLE
create list cover for list cards

### DIFF
--- a/resources/views/components/list-cover.blade.php
+++ b/resources/views/components/list-cover.blade.php
@@ -2,10 +2,10 @@
     "movies" => []
 ])
 
-<div class="m-5 grid grid-cols-2 grid-rows-2 w-16 h-24">
+<div class="w-24 grid grid-cols-2 grid-rows-2 overflow-hidden">
     @foreach (collect($movies)->take(4) as $movie)
         @php
-            $image = $movie['image'] ?? asset('images/default.jpg');
+            $image = $movie["image"] ?? asset("images/default.jpg");
         @endphp
         <img class="w-full h-full object-cover" src="{{ $image }}" alt="List cover">
     @endforeach

--- a/resources/views/components/list-cover.blade.php
+++ b/resources/views/components/list-cover.blade.php
@@ -1,0 +1,12 @@
+@props ([
+    "movies" => []
+])
+
+<div class="m-5 grid grid-cols-2 grid-rows-2 w-16 h-24">
+    @foreach (collect($movies)->take(4) as $movie)
+        @php
+            $image = $movie['image'] ?? asset('images/default.jpg');
+        @endphp
+        <img class="w-full h-full object-cover" src="{{ $image }}" alt="List cover">
+    @endforeach
+</div>


### PR DESCRIPTION
Created list cover that will be used for list cards. Image shows what the cover will look like for both mobile and desktop:

![image](https://github.com/user-attachments/assets/55de274e-80bc-4ad0-a69a-e8d416aeb7f5)

